### PR TITLE
fixed qmake paths

### DIFF
--- a/bin/qt.conf
+++ b/bin/qt.conf
@@ -1,0 +1,22 @@
+[Paths]
+# This is to get out of the bin folder
+Prefix = ..
+# This is where qmake, moc, uic are
+HostBinaries = bin
+# self-explaining
+Headers = include
+# Path to where the mkspecs folder is, see PR 134181
+Data = mkspecs
+# Path to documentation
+Documentation = doc
+# Path to where the libraries are 
+Libraries = lib
+LibraryExecutables = libexec
+# Path to where the imports are installed
+#Imports = $(QNX_TARGET)/$(CPUVARDIR)/usr/lib/qt4/imports
+Qml2Imports = qml
+# Path to where the plugins are installed
+Plugins = plugins
+# Default mkspec
+TargetSpec = blackberry-$(CPUVARDIR)-qcc
+


### PR DESCRIPTION
qmake has paths hardcoded at compile time, this was causing errors in qtcreator when adding the qt version. By adding qt.conf these paths can be overridden to the actual position of the build folder